### PR TITLE
Resolve decoding problem

### DIFF
--- a/templates/secrecy.py.j2
+++ b/templates/secrecy.py.j2
@@ -206,9 +206,11 @@ def check_between(ctx: Context, base: str, target: str):
         # Setting the commit in the context for better error message
         ctx.commit = commit
 
-        # Receive all files that were somehow changed in that commit, excluding
-        # the files that were removed.
-        cmd = ["git", "diff", "--diff-filter=d", "--name-only", f'{commit}^', commit]
+        # Options needed to resolve problems with non-standard encoding in the file path.
+        # '-c' - Pass a configuration parameter to the command.
+        # 'core.quotepath=off' - to disable quote "unusual" characters in the pathname.
+
+        cmd = ["git", '-c', 'core.quotepath=off', "diff", "--diff-filter=d", "--name-only", f'{commit}^', commit]
         files = subprocess.check_output(cmd)
         for file in files.splitlines():
             filestr = file.decode()

--- a/templates/secrecy.py.j2
+++ b/templates/secrecy.py.j2
@@ -206,6 +206,9 @@ def check_between(ctx: Context, base: str, target: str):
         # Setting the commit in the context for better error message
         ctx.commit = commit
 
+        # Receive all files that were somehow changed in that commit, excluding
+        # the files that were removed.
+
         # Options needed to resolve problems with non-standard encoding in the file path.
         # '-c' - Pass a configuration parameter to the command.
         # 'core.quotepath=off' - to disable quote "unusual" characters in the pathname.


### PR DESCRIPTION
Опции нужны для предотвращения падения скрипта проверки секретов в случае появления нестандартных символов в пути до файла.
Пример:
```
app/views/user_mailer/crypto_transaction.slim
"app/views/user_mailer/deposit_sepa\342\200\213.slim"
app/views/user_mailer/transaction.slim
"app/views/user_mailer/withdraw_sepa\342\200\213.slim"
```
Опции удаляют кавычки, которые добавляются гитом при возникновении символов, закодированных байтом со значениями больше 0x80 (https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath)