### PR TITLE
Increase shared memory size

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
           hostname: "{{ gitlab_host_name }}"
           environment:
             GITLAB_OMNIBUS_CONFIG: "{{ gitlab_omnibus_config }}"
+          shm_size: 4gb
           restart: always
 
 - name: Import backup.yml


### PR DESCRIPTION
There are errors in gitlab log related to enoent due to shm size. Fix this giving more memory to gitlab container.